### PR TITLE
Implement NATIVE_WINDOW_DEFAULT_DATASPACE EGL window query

### DIFF
--- a/src/platforms/android/client/egl_native_surface_interpreter.cpp
+++ b/src/platforms/android/client/egl_native_surface_interpreter.cpp
@@ -21,6 +21,7 @@
 #include "mir/frontend/client_constants.h"
 #include "mir/client_buffer.h"
 #include <system/window.h>
+#include <system/graphics.h>
 #include <hardware/gralloc.h>
 #include <stdexcept>
 
@@ -98,6 +99,8 @@ int mcla::EGLNativeSurfaceInterpreter::driver_requests_info(int key) const
                 return hardware_bits;
             else
                 return software_bits;
+        case NATIVE_WINDOW_DEFAULT_DATASPACE:
+            return HAL_DATASPACE_UNKNOWN;
         default:
             throw std::runtime_error("driver requested unsupported query");
     }

--- a/src/platforms/android/server/server_render_window.cpp
+++ b/src/platforms/android/server/server_render_window.cpp
@@ -26,6 +26,7 @@
 #include "interpreter_resource_cache.h"
 
 #include <system/window.h>
+#include <system/graphics.h>
 #include <boost/throw_exception.hpp>
 #include <stdexcept>
 #include <sstream>
@@ -94,6 +95,8 @@ int mga::ServerRenderWindow::driver_requests_info(int key) const
             return NATIVE_WINDOW_FRAMEBUFFER;
         case NATIVE_WINDOW_CONSUMER_USAGE_BITS:
             return GRALLOC_USAGE_HW_RENDER | GRALLOC_USAGE_HW_COMPOSER | GRALLOC_USAGE_HW_FB;
+        case NATIVE_WINDOW_DEFAULT_DATASPACE:
+            return HAL_DATASPACE_UNKNOWN;
         default:
             {
             std::stringstream sstream;


### PR DESCRIPTION
Fixes Mir on MediaTek MT6797T SoC