### PR TITLE
Initialize fake SurfaceFlinger from libminisf if present

### DIFF
--- a/cmake/FindLibHardware.cmake
+++ b/cmake/FindLibHardware.cmake
@@ -15,7 +15,12 @@ find_library(LIBHARDWARE_LIBRARY
                  libhardware.so
 )
 
-set(LIBHARDWARE_LIBRARIES ${LIBHARDWARE_LIBRARY})
+find_library(LIBHYBRIS_COMMON_LIBRARY
+   NAMES         libhybris-common.so.1
+                 libhybris-common.so
+)
+
+set(LIBHARDWARE_LIBRARIES ${LIBHARDWARE_LIBRARY} ${LIBHYBRIS_COMMON_LIBRARY})
 
 # handle the QUIETLY and REQUIRED arguments and set LIBHARDWARE_FOUND to TRUE
 # if all listed variables are TRUE

--- a/src/platforms/android/server/hal_component_factory.h
+++ b/src/platforms/android/server/hal_component_factory.h
@@ -59,6 +59,7 @@ public:
 
 private:
     std::unique_ptr<CommandStreamSyncFactory> create_command_stream_sync_factory();
+    void start_fake_surfaceflinger();
 
     std::shared_ptr<DisplayResourceFactory> const res_factory;
     std::shared_ptr<HwcReport> const hwc_report;


### PR DESCRIPTION
Ported from from mer-hybris/qt5-qpa-hwcomposer-plugin@c986132 and needed for Gemini PDA camera to work.

It should help with other Android 7 devices as well, as halium-7.1 does not have the following commit:
ubports/android_frameworks_native@ac0afed7230dfc01c26150956299b3c2643f70de. It is not needed with libminsf from sailfishos/drodmedia, as ISurfaceComposer is provided (simply porting that commit is not enough at least for Gemini).