### PR TITLE
Backport "Add miral::Output::id()" from upstream

### DIFF
--- a/debian/libmiral3.symbols
+++ b/debian/libmiral3.symbols
@@ -333,6 +333,7 @@ libmiral.so.3 libmiral3 #MINVER#
  (c++)"miral::MirRunner::config_file[abi:cxx11]() const@MIRAL_2.4" 2.4.0
  (c++)"miral::MirRunner::display_config_file[abi:cxx11]() const@MIRAL_2.4" 2.4.0
  MIRAL_2.5@MIRAL_2.5 2.5.0
+ (c++)"miral::Output::id() const@MIRAL_2.5" 2.5.0
  (c++)"miral::WaylandExtensions::set_filter(std::function<bool (std::shared_ptr<mir::scene::Session> const&, char const*)> const&)@MIRAL_2.5" 2.5.0
  (c++)"miral::WaylandExtensions::add_extension(miral::WaylandExtensions::Builder const&)@MIRAL_2.5" 2.5.0
  (c++)"miral::WaylandExtensions::add_extension_disabled_by_default(miral::WaylandExtensions::Builder const&)@MIRAL_2.5" 2.5.0

--- a/include/miral/miral/output.h
+++ b/include/miral/miral/output.h
@@ -95,6 +95,10 @@ public:
     /// current mode and orientation (rotation)
     auto extents() const -> Rectangle;
 
+    /// Mir's internal output ID
+    /// mostly useful for matching against a miral::WindowInfo::output_id
+    auto id() const -> int;
+
     auto valid() const -> bool;
 
     auto is_same_output(Output const& other) const -> bool;

--- a/src/miral/output.cpp
+++ b/src/miral/output.cpp
@@ -85,6 +85,11 @@ auto miral::Output::extents() const -> Rectangle
     return self->extents();
 }
 
+auto miral::Output::id() const -> int
+{
+    return self->id.as_value();
+}
+
 auto miral::Output::valid() const -> bool
 {
     return self->valid();

--- a/src/miral/symbols.map
+++ b/src/miral/symbols.map
@@ -375,6 +375,7 @@ global:
 MIRAL_2.5 {
 global:
   extern "C++" {
+    miral::Output::id*;
     miral::MinimalWindowManager::?MinimalWindowManager*;
     miral::MinimalWindowManager::MinimalWindowManager*;
     miral::MinimalWindowManager::advise_focus_gained*;


### PR DESCRIPTION
This is required for my multiscreen fix as currently we don't export screens id with miral and this is needed for screen matching in qtmir.  