### PR TITLE
[server/input] Use a sorted map for outputs

### DIFF
--- a/src/server/input/basic_seat.cpp
+++ b/src/server/input/basic_seat.cpp
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 #include <array>
+#include <map>
 
 namespace mi = mir::input;
 namespace mf = mir::frontend;
@@ -160,7 +161,7 @@ struct mi::BasicSeat::OutputTracker : mg::DisplayConfigurationObserver
 private:
     mutable std::mutex output_mutex;
     mi::SeatInputDeviceTracker& input_state_tracker;
-    std::unordered_map<uint32_t, mi::OutputInfo> outputs;
+    std::map<uint32_t, mi::OutputInfo> outputs;
     geom::Rectangle bounding_rectangle;
 };
 
@@ -236,4 +237,3 @@ void mi::BasicSeat::reset_confinement_regions()
 {
     input_state_tracker.reset_confinement_regions();
 }
-


### PR DESCRIPTION
This changes the map of outputs from a unordered map to a sorted map, as
mir takes the first output as default for touch screens if not otherwise
is provided. it makes no sense for this to give a different result
depending on whats first in the unordered_map bucket.

This fixes: https://github.com/ubports/ubuntu-touch/issues/1324 
pr upstream: https://github.com/MirServer/mir/pull/1162