### PR TITLE
[MirAL] Implement a "no active window" state

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,13 @@
+String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo,lintian.txt'
+String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo'
+
 pipeline {
   agent any
   stages {
     stage('Build source') {
       steps {
         sh '/usr/bin/build-source.sh'
-        stash(name: 'source', includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt')
+        stash(name: 'source', includes: stashFileList)
         cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
       }
     }
@@ -17,7 +20,7 @@ pipeline {
               unstash 'source'
               sh '''export architecture="armhf"
 build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-armhf')
+              stash(includes: stashFileList, name: 'build-armhf')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
 
@@ -29,7 +32,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="arm64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-arm64')
+              stash(includes: stashFileList, name: 'build-arm64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           },
@@ -39,7 +42,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="amd64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-amd64')
+              stash(includes: stashFileList, name: 'build-amd64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           }
@@ -52,7 +55,7 @@ build-binary.sh'''
         unstash 'build-armhf'
         unstash 'build-arm64'
         unstash 'build-amd64'
-        archiveArtifacts(artifacts: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo', fingerprint: true, onlyIfSuccessful: true)
+        archiveArtifacts(artifacts: archiveFileList, fingerprint: true, onlyIfSuccessful: true)
         sh '''/usr/bin/build-repo.sh'''
       }
     }

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -202,7 +202,7 @@ void miral::BasicWindowManager::remove_surface(
 
 void miral::BasicWindowManager::remove_window(Application const& application, miral::WindowInfo const& info)
 {
-    bool const is_active_window{mru_active_windows.top() == info.window()};
+    bool const is_active_window{active_window() == info.window()};
     auto const workspaces_containing_window = workspaces_containing(info.window());
 
     {

--- a/src/miral/basic_window_manager.cpp
+++ b/src/miral/basic_window_manager.cpp
@@ -511,7 +511,7 @@ void miral::BasicWindowManager::force_close(Window const& window)
 
 auto miral::BasicWindowManager::active_window() const -> Window
 {
-    return mru_active_windows.top();
+    return allow_active_window ? mru_active_windows.top() : Window{};
 }
 
 void miral::BasicWindowManager::focus_next_application()
@@ -1324,6 +1324,9 @@ void miral::BasicWindowManager::invoke_under_lock(std::function<void()> const& c
 auto miral::BasicWindowManager::select_active_window(Window const& hint) -> miral::Window
 {
     auto const prev_window = active_window();
+
+    // Lomiri "selects" a null Window to implicitly disable the active window
+    allow_active_window = hint;
 
     if (!hint)
     {

--- a/src/miral/basic_window_manager.h
+++ b/src/miral/basic_window_manager.h
@@ -223,6 +223,7 @@ private:
     uint64_t last_input_event_timestamp{0};
     MirEvent const* last_input_event{nullptr};
     miral::MRUWindowList mru_active_windows;
+    bool allow_active_window = true;
     std::set<Window> fullscreen_surfaces;
     std::set<Window> maximized_surfaces;
 

--- a/tests/miral/active_window.cpp
+++ b/tests/miral/active_window.cpp
@@ -488,3 +488,21 @@ TEST_F(ActiveWindow, when_focus_changes_parents_gain_focus_first)
 
     EXPECT_TRUE(sync3.signal_raised());
 }
+
+TEST_F(ActiveWindow, when_null_window_is_active_dont_refocus_on_last_active_window_hidden)
+{
+    char const* const test_name = __PRETTY_FUNCTION__;
+    auto const connection = connect_client(test_name);
+
+    auto const first_window = create_window(connection, test_name, sync1);
+    auto const second_window = create_window(connection, another_name, sync2);
+
+    sync2.exec([&]{ invoke_tools([&](WindowManagerTools& tools){ tools.select_active_window(miral::Window{}); }); });
+    EXPECT_TRUE(sync2.signal_raised());
+    assert_no_active_window();
+
+    // Expect this to timeout: the first window should not receive focus
+    sync1.exec([&]{ mir_window_set_state(second_window, mir_window_state_hidden); });
+    EXPECT_FALSE(sync1.signal_raised());
+    assert_no_active_window();
+}

--- a/tests/miral/active_window.cpp
+++ b/tests/miral/active_window.cpp
@@ -506,3 +506,21 @@ TEST_F(ActiveWindow, when_null_window_is_active_dont_refocus_on_last_active_wind
     EXPECT_FALSE(sync1.signal_raised());
     assert_no_active_window();
 }
+
+TEST_F(ActiveWindow, when_null_window_is_active_dont_refocus_on_last_active_window_removed)
+{
+    char const* const test_name = __PRETTY_FUNCTION__;
+    auto const connection = connect_client(test_name);
+
+    auto const first_window = create_window(connection, test_name, sync1);
+    auto second_window = create_window(connection, another_name, sync2);
+
+    sync2.exec([&]{ invoke_tools([&](WindowManagerTools& tools){ tools.select_active_window(miral::Window{}); }); });
+    EXPECT_TRUE(sync2.signal_raised());
+    assert_no_active_window();
+
+    // Expect this to timeout: the first window should not receive focus
+    sync1.exec([&]{ second_window = Window{}; });
+    EXPECT_FALSE(sync1.signal_raised());
+    assert_no_active_window();
+}


### PR DESCRIPTION
When setting the active window to a null window, mru_active_windows
won't be updated. This commit add the `allow_active_window` flag which
will be false when a null window is set, disabling the active window.

This is used by Lomiri during spreads and other effects and animations.

Co-authored-by: Alan Griffiths <alan@octopull.co.uk>

This PR comes with Jenkinsfile update.

Fixes ubports/unity8#225.