### PR TITLE
Do not send events to windows after they are released. (And update tests to match.)

### DIFF
--- a/src/client/mir_connection.cpp
+++ b/src/client/mir_connection.cpp
@@ -576,6 +576,7 @@ MirWaitHandle* MirConnection::release_surface(
 
     mp::SurfaceId message;
     message.set_value(surface->id());
+    surface->set_event_handler([](auto, auto, auto){}, nullptr);
 
     raw_wait_handle->expect_result();
     server.release_surface(&message, void_response.get(),

--- a/src/miral/launch_app.cpp
+++ b/src/miral/launch_app.cpp
@@ -19,6 +19,7 @@
 #include "launch_app.h"
 
 #include <unistd.h>
+#include <signal.h>
 
 #include <stdexcept>
 #include <cstring>
@@ -39,6 +40,18 @@ auto miral::launch_app(
 
     if (pid == 0)
     {
+        {
+            // POSIX.1-2001 specifies that if the disposition of SIGCHLD is set to
+            // SIG_IGN or the SA_NOCLDWAIT flag is set for SIGCHLD, then children
+            // that terminate do not become zombie.
+            // We don't want any children to become zombies...
+            struct sigaction act;
+            act.sa_handler = SIG_IGN;
+            sigemptyset(&act.sa_mask);
+            act.sa_flags = SA_NOCLDWAIT;
+            sigaction(SIGCHLD, &act, NULL);
+        }
+
         if (mir_socket)
         {
             setenv("MIR_SOCKET", mir_socket.value().c_str(),  true);   // configure Mir socket
@@ -85,5 +98,3 @@ auto miral::launch_app(
 
     return pid;
 }
-
-

--- a/tests/acceptance-tests/test_client_focus_notification.cpp
+++ b/tests/acceptance-tests/test_client_focus_notification.cpp
@@ -122,27 +122,26 @@ struct ClientFocusNotification : mtf::ConnectedClientHeadlessServer
 
 TEST_F(ClientFocusNotification, a_surface_is_notified_of_receiving_focus)
 {
-    std::vector<MirWindowFocusState> const focus_sequence = {mir_window_focus_state_focused, mir_window_focus_state_unfocused};
+    std::vector<MirWindowFocusState> const focus_sequence = {mir_window_focus_state_focused};
     auto window = make_surface();
-    window->release();
     window->expect_focus_event_sequence(focus_sequence);
+    window->release();
 }
 
 TEST_F(ClientFocusNotification, two_surfaces_are_notified_of_gaining_and_losing_focus)
 {
     std::vector<MirWindowFocusState> const initial_focus = {mir_window_focus_state_focused};
     std::vector<MirWindowFocusState> const focus_sequence1 =
-        {mir_window_focus_state_focused, mir_window_focus_state_unfocused, mir_window_focus_state_focused, mir_window_focus_state_unfocused};
-    std::vector<MirWindowFocusState> const focus_sequence2 = {mir_window_focus_state_focused, mir_window_focus_state_unfocused};
+        {mir_window_focus_state_focused, mir_window_focus_state_unfocused, mir_window_focus_state_focused};
+    std::vector<MirWindowFocusState> const focus_sequence2 = {mir_window_focus_state_focused};
 
     auto surface1 = make_surface();
     surface1->expect_focus_event_sequence(initial_focus);
 
     auto surface2 = make_surface();
-
+    surface2->expect_focus_event_sequence(focus_sequence2);
     surface2->release();
-    surface1->release();
 
     surface1->expect_focus_event_sequence(focus_sequence1);
-    surface2->expect_focus_event_sequence(focus_sequence2);
+    surface1->release();
 }

--- a/tests/acceptance-tests/test_client_surface_events.cpp
+++ b/tests/acceptance-tests/test_client_surface_events.cpp
@@ -404,7 +404,7 @@ bool is_unfocus_event(MirEvent const* event)
 }
 }
 
-TEST_F(ClientSurfaceEvents, focused_window_receives_unfocus_event_on_release)
+TEST_F(ClientSurfaceEvents, focused_window__does_not_receive_unfocus_event_after_release)
 {
     using namespace testing;
     using namespace std::chrono_literals;
@@ -448,7 +448,7 @@ TEST_F(ClientSurfaceEvents, focused_window_receives_unfocus_event_on_release)
 
     mir_window_release_sync(window);
 
-    EXPECT_TRUE(unfocus_received.wait_for(10s));
+    EXPECT_FALSE(unfocus_received.wait_for(10s));
 }
 
 TEST_F(ClientSurfaceEvents, unfocused_window_does_not_receive_unfocus_event_on_release)

--- a/tests/acceptance-tests/test_custom_window_management.cpp
+++ b/tests/acceptance-tests/test_custom_window_management.cpp
@@ -675,17 +675,20 @@ TEST_F(CustomWindowManagement, when_the_window_manager_places_a_surface_the_noti
     start_server();
     auto connection = mir_connect_sync(new_connection().c_str(), __PRETTY_FUNCTION__);
 
-    PlacementCheck placement_check{placement};
-    auto surface_spec = mir_create_normal_window_spec(connection, width, height);
+    MirWindow* window{};
+    {
+        PlacementCheck placement_check{placement};
+        auto surface_spec = mir_create_normal_window_spec(connection, width, height);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    mir_window_spec_set_pixel_format(surface_spec, format);
+        mir_window_spec_set_pixel_format(surface_spec, format);
 #pragma GCC diagnostic pop
-    mir_window_spec_set_event_handler(surface_spec, &window_placement_event_callback, &placement_check);
-    auto window = mir_create_window_sync(surface_spec);
-    mir_window_spec_release(surface_spec);
+        mir_window_spec_set_event_handler(surface_spec, &window_placement_event_callback, &placement_check);
+        window = mir_create_window_sync(surface_spec);
+        mir_window_spec_release(surface_spec);
 
-    scene_surface->placed_relative(placement_);
+        scene_surface->placed_relative(placement_);
+    }
 
     mir_window_release_sync(window);
     mir_connection_release(connection);


### PR DESCRIPTION
It's https://github.com/MirServer/mir/pull/1412 but cherry-picked into xenial. Partially fixes SDL app launching (https://github.com/ubports/ubuntu-touch/issues/1409).