### PR TITLE
Mir changes to support recent Android devices

### DIFF
--- a/include/core/mir_toolkit/common.h
+++ b/include/core/mir_toolkit/common.h
@@ -251,6 +251,7 @@ typedef enum MirPixelFormat
     mir_pixel_format_rgb_565 = 7,
     mir_pixel_format_rgba_5551 = 8,
     mir_pixel_format_rgba_4444 = 9,
+    mir_pixel_format_rgba_10101002 = 10,
     /*
      * TODO: Big endian support would require additional formats in order to
      *       composite software surfaces using OpenGL (GL_RGBA/GL_BGRA_EXT):

--- a/include/core/mir_toolkit/mir_native_buffer.h
+++ b/include/core/mir_toolkit/mir_native_buffer.h
@@ -20,7 +20,7 @@
 #ifndef MIR_CLIENT_MIR_NATIVE_BUFFER_H_
 #define MIR_CLIENT_MIR_NATIVE_BUFFER_H_
 
-enum { mir_buffer_package_max = 30 };
+enum { mir_buffer_package_max = 128 };
 
 typedef enum
 {


### PR DESCRIPTION
* Increase max amount of data ints in MirBufferPackage 
* Add 10bpp + 2bpp alpha RGBA pixel format to MirPixelFormat enum 

It turned out that recent MediaTek devices, including Volla Phone, use 60+ ints inside gralloc native handle. MirBufferPackage has hardcoded max value of 30 and this causes buffer overflow. Some values of native handle also get overwritten by the next fields of MirBufferPackage struct that are after int data[mir_buffer_package_max];

On Volla Phone, the overwritten values are seemingly non-important for the driver and did not cause issues, but on other devices like Redmi Note 8 Pro with Android 10 it causes buffer passing to break completely.

This change will break ABI and require rebuild of mir-android-platform and likely MESA packages for PinePhone.