### PR TITLE
Fix Wayland clients connecting to Mir server running on nested platform

### DIFF
--- a/src/server/graphics/nested/display.cpp
+++ b/src/server/graphics/nested/display.cpp
@@ -139,7 +139,7 @@ std::unique_ptr<mir::renderer::gl::Context> mgn::detail::EGLDisplayHandle::creat
        EGL_RENDERABLE_TYPE, MIR_SERVER_EGL_OPENGL_BIT,
        EGL_NONE
     };
-    return std::make_unique<SurfacelessEGLContext>(egl_display, attribs, EGL_NO_CONTEXT);
+    return std::make_unique<SurfacelessEGLContext>(egl_display, attribs, egl_context_);
 }
 
 mgn::detail::EGLDisplayHandle::~EGLDisplayHandle() noexcept


### PR DESCRIPTION
This is needed to enable running Wayland applications with EGL buffers on mir-android-platform without switching to Wayland for Lomiri itself/Ubuntu Touch apps.