### PR TITLE
Import newer version of Wayland compositing blocking patches, don't block forever in swap_buffers

### DIFF
--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -345,7 +345,8 @@ void mgw::DisplayClient::Output::swap_buffers()
 {
     struct FrameSync
     {
-        explicit FrameSync(wl_surface* surface)
+        explicit FrameSync(wl_surface* surface) :
+            callback{wl_surface_frame(surface)}
         {
             static struct wl_callback_listener const frame_listener =
                 {
@@ -353,14 +354,16 @@ void mgw::DisplayClient::Output::swap_buffers()
                         { static_cast<FrameSync*>(data)->frame_done(args...); },
                 };
 
-            struct wl_callback *callback = wl_surface_frame(surface);
             wl_callback_add_listener(callback, &frame_listener, this);
         }
 
-        void frame_done(struct wl_callback* callback, uint32_t /*time*/)
+        ~FrameSync()
         {
             wl_callback_destroy(callback);
+        }
 
+        void frame_done(wl_callback*, uint32_t)
+        {
             std::lock_guard<decltype(mutex)> lock{mutex};
             posted = true;
             cv.notify_all();
@@ -375,6 +378,8 @@ void mgw::DisplayClient::Output::swap_buffers()
         std::mutex mutex;
         bool posted = false;
         std::condition_variable cv;
+
+        wl_callback* const callback;
     } frame_sync{surface};
 
     // Avoid throttling compositing by blocking in eglSwapBuffers().

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -28,10 +28,11 @@
 
 #include <boost/throw_exception.hpp>
 
+#include <algorithm>
+#include <condition_variable>
 #include <cstring>
 #include <stdlib.h>
 #include <system_error>
-#include <algorithm>
 
 namespace mgw = mir::graphics::wayland;
 
@@ -93,6 +94,12 @@ public:
     EGLSurface eglsurface{EGL_NO_SURFACE};
 
     std::function<void(Output const&)> on_done;
+
+    std::mutex frame_mutex;
+    bool frame_posted = false;
+    std::condition_variable frame_cv;
+
+    void frame_done(struct wl_callback* callback, uint32_t time);
 
     // DisplaySyncGroup implementation
     void for_each_display_buffer(std::function<void(DisplayBuffer&)> const& /*f*/) override;
@@ -297,8 +304,18 @@ void mgw::DisplayClient::Output::for_each_display_buffer(std::function<void(Disp
     f(*this);
 }
 
+void mgw::DisplayClient::Output::frame_done(struct wl_callback* callback, uint32_t /*time*/) {
+    wl_callback_destroy(callback);
+
+    std::lock_guard<decltype(frame_mutex)> lock{frame_mutex};
+    frame_posted = true;
+    frame_cv.notify_all();
+}
+
 void mgw::DisplayClient::Output::post()
 {
+    std::unique_lock<decltype(frame_mutex)> lock{frame_mutex};
+    frame_cv.wait(lock, [this]{ return frame_posted; });
 }
 
 auto mgw::DisplayClient::Output::recommended_sleep() const -> std::chrono::milliseconds
@@ -343,9 +360,21 @@ void mgw::DisplayClient::Output::release_current()
 void mgw::DisplayClient::Output::swap_buffers()
 {
     // Avoid throttling compositing by blocking in eglSwapBuffers().
-    // NB We can likely do even better by adding a frame callback
-    // and using that to schedule composition
     eglSwapInterval(owner->egldisplay, 0);
+
+    static struct wl_callback_listener const frame_listener =
+        {
+            [](void* data, auto... args)
+                { static_cast<mgw::DisplayClient::Output*>(data)->frame_done(args...); },
+        };
+
+    struct wl_callback *callback = wl_surface_frame(surface);
+    wl_callback_add_listener(callback, &frame_listener, this);
+
+    {
+        std::lock_guard<decltype(frame_mutex)> lock{frame_mutex};
+        frame_posted = false;
+    }
 
     if (eglSwapBuffers(owner->egldisplay, eglsurface) != EGL_TRUE)
         BOOST_THROW_EXCEPTION(egl_error("Failed to perform buffer swap"));

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -314,8 +314,6 @@ void mgw::DisplayClient::Output::frame_done(struct wl_callback* callback, uint32
 
 void mgw::DisplayClient::Output::post()
 {
-    std::unique_lock<decltype(frame_mutex)> lock{frame_mutex};
-    frame_cv.wait(lock, [this]{ return frame_posted; });
 }
 
 auto mgw::DisplayClient::Output::recommended_sleep() const -> std::chrono::milliseconds
@@ -360,6 +358,7 @@ void mgw::DisplayClient::Output::release_current()
 void mgw::DisplayClient::Output::swap_buffers()
 {
     // Avoid throttling compositing by blocking in eglSwapBuffers().
+    // Instead we use the frame "done" notification.
     eglSwapInterval(owner->egldisplay, 0);
 
     static struct wl_callback_listener const frame_listener =
@@ -371,13 +370,13 @@ void mgw::DisplayClient::Output::swap_buffers()
     struct wl_callback *callback = wl_surface_frame(surface);
     wl_callback_add_listener(callback, &frame_listener, this);
 
-    {
-        std::lock_guard<decltype(frame_mutex)> lock{frame_mutex};
-        frame_posted = false;
-    }
+    std::unique_lock<decltype(frame_mutex)> lock{frame_mutex};
+    frame_posted = false;
 
     if (eglSwapBuffers(owner->egldisplay, eglsurface) != EGL_TRUE)
         BOOST_THROW_EXCEPTION(egl_error("Failed to perform buffer swap"));
+
+    frame_cv.wait(lock, [this]{ return frame_posted; });
 }
 
 void mgw::DisplayClient::Output::bind()

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -95,12 +95,6 @@ public:
 
     std::function<void(Output const&)> on_done;
 
-    std::mutex frame_mutex;
-    bool frame_posted = false;
-    std::condition_variable frame_cv;
-
-    void frame_done(struct wl_callback* callback, uint32_t time);
-
     // DisplaySyncGroup implementation
     void for_each_display_buffer(std::function<void(DisplayBuffer&)> const& /*f*/) override;
     void post() override;
@@ -304,14 +298,6 @@ void mgw::DisplayClient::Output::for_each_display_buffer(std::function<void(Disp
     f(*this);
 }
 
-void mgw::DisplayClient::Output::frame_done(struct wl_callback* callback, uint32_t /*time*/) {
-    wl_callback_destroy(callback);
-
-    std::lock_guard<decltype(frame_mutex)> lock{frame_mutex};
-    frame_posted = true;
-    frame_cv.notify_all();
-}
-
 void mgw::DisplayClient::Output::post()
 {
 }
@@ -357,26 +343,48 @@ void mgw::DisplayClient::Output::release_current()
 
 void mgw::DisplayClient::Output::swap_buffers()
 {
+    struct FrameSync
+    {
+        explicit FrameSync(wl_surface* surface)
+        {
+            static struct wl_callback_listener const frame_listener =
+                {
+                    [](void* data, auto... args)
+                        { static_cast<FrameSync*>(data)->frame_done(args...); },
+                };
+
+            struct wl_callback *callback = wl_surface_frame(surface);
+            wl_callback_add_listener(callback, &frame_listener, this);
+        }
+
+        void frame_done(struct wl_callback* callback, uint32_t /*time*/)
+        {
+            wl_callback_destroy(callback);
+
+            std::lock_guard<decltype(mutex)> lock{mutex};
+            posted = true;
+            cv.notify_all();
+        }
+
+        void wait_for_done()
+        {
+            std::unique_lock<decltype(mutex)> lock{mutex};
+            cv.wait(lock, [this]{ return posted; });
+        }
+
+        std::mutex mutex;
+        bool posted = false;
+        std::condition_variable cv;
+    } frame_sync{surface};
+
     // Avoid throttling compositing by blocking in eglSwapBuffers().
     // Instead we use the frame "done" notification.
     eglSwapInterval(owner->egldisplay, 0);
 
-    static struct wl_callback_listener const frame_listener =
-        {
-            [](void* data, auto... args)
-                { static_cast<mgw::DisplayClient::Output*>(data)->frame_done(args...); },
-        };
-
-    struct wl_callback *callback = wl_surface_frame(surface);
-    wl_callback_add_listener(callback, &frame_listener, this);
-
-    std::unique_lock<decltype(frame_mutex)> lock{frame_mutex};
-    frame_posted = false;
-
     if (eglSwapBuffers(owner->egldisplay, eglsurface) != EGL_TRUE)
         BOOST_THROW_EXCEPTION(egl_error("Failed to perform buffer swap"));
 
-    frame_cv.wait(lock, [this]{ return frame_posted; });
+    frame_sync.wait_for_done();
 }
 
 void mgw::DisplayClient::Output::bind()

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -342,11 +342,6 @@ void mgw::DisplayClient::Output::release_current()
 
 void mgw::DisplayClient::Output::swap_buffers()
 {
-    // Avoid throttling compositing by blocking in eglSwapBuffers().
-    // NB We can likely do even better by adding a frame callback
-    // and using that to schedule composition
-    eglSwapInterval(owner->egldisplay, 0);
-
     if (eglSwapBuffers(owner->egldisplay, eglsurface) != EGL_TRUE)
         BOOST_THROW_EXCEPTION(egl_error("Failed to perform buffer swap"));
 }

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -372,7 +372,7 @@ void mgw::DisplayClient::Output::swap_buffers()
         void wait_for_done()
         {
             std::unique_lock<decltype(mutex)> lock{mutex};
-            cv.wait(lock, [this]{ return posted; });
+            cv.wait_for(lock, std::chrono::milliseconds{100}, [this]{ return posted; });
         }
 
         std::mutex mutex;

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -28,11 +28,10 @@
 
 #include <boost/throw_exception.hpp>
 
-#include <algorithm>
-#include <condition_variable>
 #include <cstring>
 #include <stdlib.h>
 #include <system_error>
+#include <algorithm>
 
 namespace mgw = mir::graphics::wayland;
 
@@ -94,12 +93,6 @@ public:
     EGLSurface eglsurface{EGL_NO_SURFACE};
 
     std::function<void(Output const&)> on_done;
-
-    std::mutex frame_mutex;
-    bool frame_posted = false;
-    std::condition_variable frame_cv;
-
-    void frame_done(struct wl_callback* callback, uint32_t time);
 
     // DisplaySyncGroup implementation
     void for_each_display_buffer(std::function<void(DisplayBuffer&)> const& /*f*/) override;
@@ -304,18 +297,8 @@ void mgw::DisplayClient::Output::for_each_display_buffer(std::function<void(Disp
     f(*this);
 }
 
-void mgw::DisplayClient::Output::frame_done(struct wl_callback* callback, uint32_t /*time*/) {
-    wl_callback_destroy(callback);
-
-    std::lock_guard<decltype(frame_mutex)> lock{frame_mutex};
-    frame_posted = true;
-    frame_cv.notify_all();
-}
-
 void mgw::DisplayClient::Output::post()
 {
-    std::unique_lock<decltype(frame_mutex)> lock{frame_mutex};
-    frame_cv.wait(lock, [this]{ return frame_posted; });
 }
 
 auto mgw::DisplayClient::Output::recommended_sleep() const -> std::chrono::milliseconds
@@ -360,21 +343,9 @@ void mgw::DisplayClient::Output::release_current()
 void mgw::DisplayClient::Output::swap_buffers()
 {
     // Avoid throttling compositing by blocking in eglSwapBuffers().
+    // NB We can likely do even better by adding a frame callback
+    // and using that to schedule composition
     eglSwapInterval(owner->egldisplay, 0);
-
-    static struct wl_callback_listener const frame_listener =
-        {
-            [](void* data, auto... args)
-                { static_cast<mgw::DisplayClient::Output*>(data)->frame_done(args...); },
-        };
-
-    struct wl_callback *callback = wl_surface_frame(surface);
-    wl_callback_add_listener(callback, &frame_listener, this);
-
-    {
-        std::lock_guard<decltype(frame_mutex)> lock{frame_mutex};
-        frame_posted = false;
-    }
 
     if (eglSwapBuffers(owner->egldisplay, eglsurface) != EGL_TRUE)
         BOOST_THROW_EXCEPTION(egl_error("Failed to perform buffer swap"));

--- a/src/platforms/wayland/displayclient.cpp
+++ b/src/platforms/wayland/displayclient.cpp
@@ -342,6 +342,11 @@ void mgw::DisplayClient::Output::release_current()
 
 void mgw::DisplayClient::Output::swap_buffers()
 {
+    // Avoid throttling compositing by blocking in eglSwapBuffers().
+    // NB We can likely do even better by adding a frame callback
+    // and using that to schedule composition
+    eglSwapInterval(owner->egldisplay, 0);
+
     if (eglSwapBuffers(owner->egldisplay, eglsurface) != EGL_TRUE)
         BOOST_THROW_EXCEPTION(egl_error("Failed to perform buffer swap"));
 }


### PR DESCRIPTION
Marius imported the patches from https://github.com/MirServer/mir/pull/1694 before they were complete. This PR reverts the incomplete patches and adds the finished versions. Not pretty, but it keeps the history linear...

Then we add a patch to prevent blocking forever in swap_buffers when Mir is running as a Wayland client under another Wayland compositor. See the commit message for more details.