### PR TITLE
Only update event in map if its there, not autocreate a new one

### DIFF
--- a/src/platforms/evdev/libinput_device.cpp
+++ b/src/platforms/evdev/libinput_device.cpp
@@ -350,7 +350,12 @@ void mie::LibInputDevice::handle_touch_down(libinput_event_touch* touch)
 void mie::LibInputDevice::handle_touch_up(libinput_event_touch* touch)
 {
     MirTouchId const id = libinput_event_touch_get_slot(touch);
-    last_seen_properties[id].action = mir_touch_action_up;
+    //Only update this id if there is a valid record in the map. Otherwise, if an invalid 
+    //"up" event is being received from a stupid panel this will create fake actions.
+    //the entry was deleted when the proper "up" event was received, but C++ map array
+    //function will insta-create a new one otherwise
+    if (last_seen_properties.count(id))
+        last_seen_properties[id].action = mir_touch_action_up;
 }
 
 void mie::LibInputDevice::update_contact_data(ContactData & data, MirTouchAction action, libinput_event_touch* touch)

--- a/src/platforms/evdev/libinput_device.cpp
+++ b/src/platforms/evdev/libinput_device.cpp
@@ -354,7 +354,8 @@ void mie::LibInputDevice::handle_touch_up(libinput_event_touch* touch)
     //"up" event is being received from a stupid panel this will create fake actions.
     //the entry was deleted when the proper "up" event was received, but C++ map array
     //function will insta-create a new one otherwise
-    if (last_seen_properties.count(id))
+    auto const i = last_seen_properties.find(id);
+    if (i != end(last_seen_properties))
         last_seen_properties[id].action = mir_touch_action_up;
 }
 


### PR DESCRIPTION
This was discovered on Oneplus 5T: When a notification arrives and the screen wakes up and panel is waking up too there will be an immediate 10-finger touch event coming with invalid "all fingers up" data. This should be ignored, otherwise Mir thinks the user is doing smth and l-s-c tells repowerd to extand power state to normal screen off time, not just briefly leave display on.
Only update the list of active touch events if there is a valid record in the map. Otherwise, if an invalid "up" event is being received from a stupid panel this will create fake actions. The entry was deleted when the proper "up" event was received, but C++ map array function will insta-create a new one otherwise