### PR TITLE
Filter out some confusing libinput events

### DIFF
--- a/src/platforms/evdev/libinput_device.cpp
+++ b/src/platforms/evdev/libinput_device.cpp
@@ -345,11 +345,11 @@ mir::EventUPtr mie::LibInputDevice::convert_touch_frame(libinput_event_touch* to
     // to (0, 0) coordinates. Detect those and drop the whole frame in this case.
     // Also drop touch frames with no contacts inside
     int emptyTouches = 0;
-    for_each(begin(contacts), end(contacts), [&](auto const& contact)
+    for (const auto &contact: contacts)
     {
         if (contact.x == 0 && contact.y == 0)
             emptyTouches++;
-    });
+    }
     if (contacts.empty() || emptyTouches > 1)
         return {nullptr, [](auto){}};
     
@@ -371,7 +371,7 @@ void mie::LibInputDevice::handle_touch_up(libinput_event_touch* touch)
     //create a fake action.
     auto const it = last_seen_properties.find(id);
     if (it != end(last_seen_properties))
-        (*it).second.action = mir_touch_action_up;
+        it->second.action = mir_touch_action_up;
 }
 
 void mie::LibInputDevice::update_contact_data(ContactData & data, MirTouchAction action, libinput_event_touch* touch)

--- a/src/platforms/evdev/libinput_device.cpp
+++ b/src/platforms/evdev/libinput_device.cpp
@@ -177,7 +177,10 @@ void mie::LibInputDevice::process_event(libinput_event* event)
         case LIBINPUT_EVENT_TOUCH_FRAME:
             if (is_output_active())
             {
-                sink->handle_input(convert_touch_frame(libinput_event_get_touch_event(event)));
+                if (auto input = convert_touch_frame(libinput_event_get_touch_event(event)))
+                {
+                    sink->handle_input(std::move(input));
+                }
             }
             break;
         default:
@@ -338,6 +341,18 @@ mir::EventUPtr mie::LibInputDevice::convert_touch_frame(libinput_event_touch* to
             ++it;
     }
 
+    // Sanity check: Bogus panels are sending sometimes empty events that all point
+    // to (0, 0) coordinates. Detect those and drop the whole frame in this case.
+    // Also drop touch frames with no contacts inside
+    int emptyTouches = 0;
+    for_each(begin(contacts), end(contacts), [&](auto const& contact)
+    {
+        if (contact.x == 0 && contact.y == 0)
+            emptyTouches++;
+    });
+    if (contacts.empty() || emptyTouches > 1)
+        return {nullptr, [](auto){}};
+    
     return builder->touch_event(time, contacts);
 }
 
@@ -350,7 +365,13 @@ void mie::LibInputDevice::handle_touch_down(libinput_event_touch* touch)
 void mie::LibInputDevice::handle_touch_up(libinput_event_touch* touch)
 {
     MirTouchId const id = libinput_event_touch_get_slot(touch);
-    last_seen_properties[id].action = mir_touch_action_up;
+
+    //Only update last_seen_properties[].action if there is a valid record in the map
+    //for this ID. Otherwise, an invalid "up" event from a bogus panel will
+    //create a fake action.
+    auto const it = last_seen_properties.find(id);
+    if (it != end(last_seen_properties))
+        (*it).second.action = mir_touch_action_up;
 }
 
 void mie::LibInputDevice::update_contact_data(ContactData & data, MirTouchAction action, libinput_event_touch* touch)

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -604,8 +604,8 @@ TEST_F(LibInputDeviceOnTouchScreen, process_event_does_not_ignore_valid_touch_ev
     float orientation = 0;
 
     InSequence seq;
-    EXPECT_CALL(mock_builder, touch_event(_, _)).Times(0);
-    EXPECT_CALL(mock_sink, handle_input(_)).Times(0);
+    EXPECT_CALL(mock_builder, touch_event(_, _)).Times(1);
+    EXPECT_CALL(mock_sink, handle_input(_)).Times(1);
 
     touch_screen.start(&mock_sink, &mock_builder);
     env.mock_libinput.setup_touch_event(fake_device, LIBINPUT_EVENT_TOUCH_DOWN, event_time_1, slot1, x, y, major, minor,

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -64,6 +64,7 @@ public:
 };
 
 using namespace ::testing;
+using ::testing::_;
 using Matrix = mi::OutputInfo::Matrix;
 
 struct MockEventBuilder : mi::EventBuilder
@@ -540,6 +541,46 @@ TEST_F(LibInputDeviceOnTouchScreen, process_event_handles_touch_down_events)
     touch_screen.start(&mock_sink, &mock_builder);
     env.mock_libinput.setup_touch_event(fake_device, LIBINPUT_EVENT_TOUCH_DOWN, event_time_1, slot, x, y, major, minor,
                                         pressure, orientation);
+    env.mock_libinput.setup_touch_frame(fake_device, event_time_1);
+    process_events(touch_screen);
+}
+
+TEST_F(LibInputDeviceOnTouchScreen, process_event_ignores_uncorrelated_touch_up_events)
+{
+    MirTouchId slot = 3;
+
+    InSequence seq;
+
+    EXPECT_CALL(mock_builder, touch_event(_, _)).Times(0);
+    EXPECT_CALL(mock_sink, handle_input(_)).Times(0);
+
+    touch_screen.start(&mock_sink, &mock_builder);
+    env.mock_libinput.setup_touch_up_event(fake_device, event_time_1, slot);
+    env.mock_libinput.setup_touch_frame(fake_device, event_time_1);
+    process_events(touch_screen);
+}
+
+TEST_F(LibInputDeviceOnTouchScreen, process_event_ignores_excessive_touch_events_on_coordinate_0_0)
+{
+    MirTouchId slot1 = 0, slot2 = 1;
+    float major = 0;
+    float minor = 0;
+    float pressure = 0.0f;
+    float x = 0;
+    float y = 0;
+    float orientation = 0;
+
+    InSequence seq;
+    EXPECT_CALL(mock_builder, touch_event(_, _)).Times(0);
+    EXPECT_CALL(mock_sink, handle_input(_)).Times(0);
+
+    touch_screen.start(&mock_sink, &mock_builder);
+    env.mock_libinput.setup_touch_event(fake_device, LIBINPUT_EVENT_TOUCH_DOWN, event_time_1, slot1, x, y, major, minor,
+                                        pressure, orientation);
+    env.mock_libinput.setup_touch_up_event(fake_device, event_time_1, slot1);
+    env.mock_libinput.setup_touch_event(fake_device, LIBINPUT_EVENT_TOUCH_DOWN, event_time_1, slot2, x, y, major, minor,
+                                        pressure, orientation);
+    env.mock_libinput.setup_touch_up_event(fake_device, event_time_1, slot2);
     env.mock_libinput.setup_touch_frame(fake_device, event_time_1);
     process_events(touch_screen);
 }

--- a/tests/unit-tests/input/evdev/test_libinput_device.cpp
+++ b/tests/unit-tests/input/evdev/test_libinput_device.cpp
@@ -562,6 +562,39 @@ TEST_F(LibInputDeviceOnTouchScreen, process_event_ignores_uncorrelated_touch_up_
 
 TEST_F(LibInputDeviceOnTouchScreen, process_event_ignores_excessive_touch_events_on_coordinate_0_0)
 {
+    MirTouchId slot1 = 0, slot2 = 1, slot3 = 2;
+    float major = 0;
+    float minor = 0;
+    float pressure = 0.0f;
+    float x = 0;
+    float y = 0;
+    float orientation = 0;
+
+    InSequence seq;
+    EXPECT_CALL(mock_builder, touch_event(_, _)).Times(0);
+    EXPECT_CALL(mock_sink, handle_input(_)).Times(0);
+
+    touch_screen.start(&mock_sink, &mock_builder);
+
+    //Add 2 touches on coordinate 0,0 - this should be detected as a spurious touch
+    env.mock_libinput.setup_touch_event(fake_device, LIBINPUT_EVENT_TOUCH_DOWN, event_time_1, slot1, x, y, major, minor,
+                                        pressure, orientation);
+    env.mock_libinput.setup_touch_up_event(fake_device, event_time_1, slot1);
+    env.mock_libinput.setup_touch_event(fake_device, LIBINPUT_EVENT_TOUCH_DOWN, event_time_1, slot2, x, y, major, minor,
+                                        pressure, orientation);
+    env.mock_libinput.setup_touch_up_event(fake_device, event_time_1, slot2);
+
+    //Add another valid touch down event to make sure the frame is really not processed
+    env.mock_libinput.setup_touch_event(fake_device, LIBINPUT_EVENT_TOUCH_DOWN, event_time_1, slot3, 1, 1, major, minor,
+                                        pressure, orientation);
+    env.mock_libinput.setup_touch_up_event(fake_device, event_time_1, slot3);
+
+    env.mock_libinput.setup_touch_frame(fake_device, event_time_1);
+    process_events(touch_screen);
+}
+
+TEST_F(LibInputDeviceOnTouchScreen, process_event_does_not_ignore_valid_touch_events_on_coordinate_0_0)
+{
     MirTouchId slot1 = 0, slot2 = 1;
     float major = 0;
     float minor = 0;
@@ -578,7 +611,7 @@ TEST_F(LibInputDeviceOnTouchScreen, process_event_ignores_excessive_touch_events
     env.mock_libinput.setup_touch_event(fake_device, LIBINPUT_EVENT_TOUCH_DOWN, event_time_1, slot1, x, y, major, minor,
                                         pressure, orientation);
     env.mock_libinput.setup_touch_up_event(fake_device, event_time_1, slot1);
-    env.mock_libinput.setup_touch_event(fake_device, LIBINPUT_EVENT_TOUCH_DOWN, event_time_1, slot2, x, y, major, minor,
+    env.mock_libinput.setup_touch_event(fake_device, LIBINPUT_EVENT_TOUCH_DOWN, event_time_1, slot2, 1, 1, major, minor,
                                         pressure, orientation);
     env.mock_libinput.setup_touch_up_event(fake_device, event_time_1, slot2);
     env.mock_libinput.setup_touch_frame(fake_device, event_time_1);


### PR DESCRIPTION
This is adopted form upstream https://github.com/MirServer/mir/pull/2299 ...
It will add filtering for 2 scenarios of wrong/confusing events from libinput:

- Getting 2 consecutive "up" events for a touch down event (theoretical fix, not observed)
- Getting fake touch events after screen poweron all point to 0,0 coordinates (observed on a Synaptics touchscreen on Oneplus 5T)